### PR TITLE
Fix urllib3 incompatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,6 @@ RUN set -ex \
         pytest==7.1.2 \
         tavern==1.23.1 \
         allure-pytest==2.12.0 \
-    && /usr/bin/yes | pip3 uninstall requests \
-    && pip3 install requests==2.28.1 \
     && apk del \
         python3-dev \
         tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN set -ex \
         pytest==7.1.2 \
         tavern==1.23.1 \
         allure-pytest==2.12.0 \
+    && /usr/bin/yes | pip3 uninstall requests \
+    && pip3 install requests==2.28.1 \
     && apk del \
         python3-dev \
         tar \

--- a/csm-manifest-extractor-configuration.yaml
+++ b/csm-manifest-extractor-configuration.yaml
@@ -40,7 +40,7 @@ configuration:
   targeted-csm-branches:
     - main
     - release/1.6
-    - release/1.5
+    - stable/1.5
     - release/1.4
   docker-image-manifest: docker/index.yaml
   helm-manifest-directory: manifests

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tavern==1.23.1
 pytest==7.1.2
 jinja2==3.1.2
 semver==2.13.0
+urllib3<2


### PR DESCRIPTION
### Summary and Scope

This change resolves failures encountered during the Nightly Integration runs by pinning to an older version of urllib3 to prevent an incompatibility introduced in v2.

### Issues and Related PRs

* N/A

### Testing

Night Integration GitHub Actions workflow executed and completed successfully.

### Risks and Mitigations

None.